### PR TITLE
VCFSimilarity: Add missing graxxia import

### DIFF
--- a/src/main/groovy/VCFSimilarity.groovy
+++ b/src/main/groovy/VCFSimilarity.groovy
@@ -4,6 +4,7 @@ import gngs.ProgressCounter
 import gngs.VCF
 import gngs.Variant
 import graxxia.Matrix
+import graxxia.Stats
 
 /**
  * A simple measurement of similarity of different samples by counting the number of 


### PR DESCRIPTION
Seems to fix the following bug:

Exception in thread "main" java.lang.IllegalArgumentException: No column named Stats in this Matrix